### PR TITLE
Use narrow-to-region

### DIFF
--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -71,16 +71,16 @@ applying the regional features of `evil-numbers/inc-at-point'.
   (interactive "p*")
   (cond
    ((and (not no-region) (region-active-p))
-    (let (deactivate-mark
-          (rb (region-beginning))
-          (re (region-end)))
+    (let (deactivate-mark)
       (save-excursion
         (save-match-data
-          (goto-char rb)
-          (while (re-search-forward "\\(?:0\\(?:[Bb][01]+\\|[Oo][0-7]+\\|[Xx][0-9A-Fa-f]+\\)\\|-?[0-9]+\\)" re t)
-            (evil-numbers/inc-at-pt amount 'no-region)
-            ;; Undo vim compatability.
-            (forward-char 1)))))
+          (save-restriction
+            (narrow-to-region (region-beginning) (region-end))
+            (goto-char (point-min))
+            (while (re-search-forward "\\(?:0\\(?:[Bb][01]+\\|[Oo][0-7]+\\|[Xx][0-9A-Fa-f]+\\)\\|-?[0-9]+\\)" nil t)
+              (evil-numbers/inc-at-pt amount 'no-region)
+              ;; Undo vim compatability.
+              (forward-char 1))))))
     (setq deactivate-mark t))
    (t
     (save-match-data


### PR DESCRIPTION
This should fix the problem that when the number inside the region
changes, the end of the region might also changes.

For example, when the region contains "9 10", first we will increase 9 to 10, then the region end is changed. Actually the Emacs would issue an error: "Invalid search bound (wrong side of point)" in this case. Using narrow-to-region can avoid such problem.

By the way, I think it is better to remove the `deactivate-mark` in the code for the region. If we do that, the region is still active after we do `evil-numbers/inc-at-pt` or `evil-numbers/dec-at-pt`, so we can repeatedly increase/decrease the numbers in the region, and we can also do some other things for the region(copy, kill, etc.). Right now the user has to reselect the region after they use  `evil-numbers/inc-at-pt` or `evil-numbers/dec-at-pt`. But this is only my personal favor, and I didn't include this change in this pull request. You decide. :-)
