### PR TITLE
Add convenient wrapper for repetition

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,8 +17,9 @@
    Put in =load-path=, =(require 'evil-numbers)= and bind, for example:
 
    #+BEGIN_SRC emacs-lisp
-     (global-set-key (kbd "C-c +") 'evil-numbers/inc-at-pt)
-     (global-set-key (kbd "C-c -") 'evil-numbers/dec-at-pt)
+     (global-set-key (kbd "C-c C-+") 'evil-numbers/adjust)
+     (global-set-key (kbd "C-c C-=") 'evil-numbers/adjust)
+     (global-set-key (kbd "C-c C--") 'evil-numbers/adjust)
    #+END_SRC
 
    or only in evil's normal state:


### PR DESCRIPTION
Hi,

This is an implementation for repetitive modification of numbers.  I'm not a evil user so not sure how I should change the keymap for evil mode.  For normal use, however, it seems to work for me.

One thing I'm not sure about is the way to call evil-numbers/inc-at-pt recursively.  The current implementation is straightforward; no consideration is given to the recursive call.  Please let me know if I need to do something.

Here is the original commit log:

> Add `evil-numbers/adjust' special wrapper for repetitive increments /
> decrements.  This wrapper allows you to hit`+' or `-' to increment
> consecutively.  That is, the following key sequence increases the number
> 1 to 4:
> 
> C-c = = =
> 
> if you map the wrapper to `C-c ='.
> 
> The implementation is shamelessly taken from `text-scale-adjust' in
> face-remap.el.

Hope you like it.  
