### PR TITLE
Use pirvate variable/function separators for private functions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,10 @@
+0.5
+	- Add support for block selections
+  - Add support for subscript and superscript numbers
+  - Make padding optinal
+  - Fix numbers being pushed out of selections (e.g. calling inc-at-pt on ^9 9$
+    where ^$ denote the start and end of the selection would result in 10 9).
+  - Pad negative numbers and add a plus sign if a negative number is turned into
+    a positive number (if padding is enabled)
+  - Add g C-a like functionality (i.e. increment first number in selection by 1,
+    second one by 2 and so on)

--- a/README.org
+++ b/README.org
@@ -55,9 +55,9 @@
    Position cursor on literal and play with your numbers!
 
 ** Known Bugs
-   See http://github.com/janpath/evil-numbers/issues
+   See http://github.com/juliapath/evil-numbers/issues
 
 ** Contributors
    - Matthew Fidler <matthew.fidler@gmail.com>
    - Michael Markert <markert.michael@gmail.com>
-   - Jan Path <jan@jpath.de>
+   - Julia Path <julia@jpath.de>

--- a/README.org
+++ b/README.org
@@ -8,6 +8,8 @@
     numbers within that region will be incremented/decremented (unlike
     in vim)
 
+  - Increment/decrement numbers incrementally like g C-a/g C-x in vim.
+
 ** Detected Literals
     - binary, e.g. =0b0101=, =0B0101=
     - octal, e.g. =0o755=, =0O700=
@@ -19,6 +21,8 @@
    #+BEGIN_SRC emacs-lisp
      (global-set-key (kbd "C-c +") 'evil-numbers/inc-at-pt)
      (global-set-key (kbd "C-c -") 'evil-numbers/dec-at-pt)
+     (global-set-key (kbd "C-c C-+") 'evil-numbers/inc-at-pt-incremental)
+     (global-set-key (kbd "C-c C--") 'evil-numbers/dec-at-pt-incremental)
    #+END_SRC
 
    or only in evil's normal state:
@@ -26,6 +30,8 @@
    #+BEGIN_SRC emacs-lisp
     (define-key evil-normal-state-map (kbd "C-c +") 'evil-numbers/inc-at-pt)
     (define-key evil-normal-state-map (kbd "C-c -") 'evil-numbers/dec-at-pt)
+    (define-key evil-normal-state-map (kbd "C-c C-+") 'evil-numbers/inc-at-pt-incremental)
+    (define-key evil-normal-state-map (kbd "C-c C--") 'evil-numbers/dec-at-pt-incremental)
    #+END_SRC
 
    For window system users the keypad =+= and =-= present an alternative that can be
@@ -34,6 +40,8 @@
    #+BEGIN_SRC emacs-lisp
    (define-key evil-normal-state-map (kbd "<kp-add>") 'evil-numbers/inc-at-pt)
    (define-key evil-normal-state-map (kbd "<kp-subtract>") 'evil-numbers/dec-at-pt)
+   (define-key evil-normal-state-map (kbd "C-<kp-add>") 'evil-numbers/inc-at-pt-incremental)
+   (define-key evil-normal-state-map (kbd "C-<kp-subtract>") 'evil-numbers/dec-at-pt-incremental)
    #+END_SRC
 
 ** Usage

--- a/README.org
+++ b/README.org
@@ -2,7 +2,9 @@
   - Increment / Decrement binary, octal, decimal and hex literals
 
   - works like C-a/C-x in vim, i.e. searches for number up to eol and then
-    increments or decrements and keep zero padding up (unlike in vim)
+    increments or decrements 
+
+  - Can keep zero padding up (off by default)
 
   - When a region is active, as in evil's visual mode, all the
     numbers within that region will be incremented/decremented (unlike
@@ -14,6 +16,7 @@
     - binary, e.g. =0b0101=, =0B0101=
     - octal, e.g. =0o755=, =0O700=
     - hexadecimal, e.g. =0xDEADBEEF=, =0XCAFE=
+    - unicode superscript and subscript, e.g. =²= and =₁=.
 
 ** Install
    Put in =load-path=, =(require 'evil-numbers)= and bind, for example:
@@ -43,13 +46,18 @@
    (define-key evil-normal-state-map (kbd "C-<kp-add>") 'evil-numbers/inc-at-pt-incremental)
    (define-key evil-normal-state-map (kbd "C-<kp-subtract>") 'evil-numbers/dec-at-pt-incremental)
    #+END_SRC
+   
+  Set =evil-numbers/padDefault= to =t= if you want numbers to be padded with
+  zeros (numbers with a leading zero are always padded). If you want both
+  behaviours, all commands take an optional argument =padded=.
 
 ** Usage
    Position cursor on literal and play with your numbers!
 
 ** Known Bugs
-   See http://github.com/cofi/evil-numbers/issues
+   See http://github.com/janpath/evil-numbers/issues
 
 ** Contributors
    - Matthew Fidler <matthew.fidler@gmail.com>
    - Michael Markert <markert.michael@gmail.com>
+   - Jan Path <jan@jpath.de>

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -89,29 +89,29 @@
             (number-sequence 0 9)))))
 
 (defgroup evil-numbers nil
-  ""
+  "Support number increment/decrement."
   :group 'convenience)
 
 ;;;###autoload
 (defcustom evil-numbers/padDefault nil
-  "Whether numbers are padded by default"
+  "Whether numbers are padded by default."
   :group 'evil-numbers
   :type 'boolean
   :options '(nil t))
 
 (defun evil-numbers/swap-alist (alist)
-  "Swap association list"
+  "Swap association list ALIST."
   (mapcar (lambda (x) (cons (cdr x) (car x))) alist))
 
 (defun evil-numbers/translate-with-alist (alist string)
-  "Translate every symbol in string using alist"
+  "Translate every symbol in STRING using ALIST."
   (funcall
    (if (stringp string) #'concat (lambda (x) x))
    (mapcar (lambda (c) (cdr (assoc c alist))) string)))
 
 ;;;###autoload (autoload 'evil-numbers/inc-at-pt "evil-numbers" nil t)
 (evil-define-operator evil-numbers/inc-at-pt (amount beg end type &optional incremental padded)
-  "Increment the number at point or after point before end-of-line by AMOUNT.
+  "Increment the number at point or after point before `end-of-line' by AMOUNT.
 When region is selected, increment all numbers in the region by AMOUNT
 
 NO-REGION is internal flag that allows
@@ -126,9 +126,7 @@ behaviour set by `evil-numbers/pad-default', t is the opposite of
 `evil-numbers/pad-default', '(t) enables padding and '(nil) disables padding.
 Numbers with a leading zero are always padded. Signs are preserved when padding
 is enabled, i.e. increasing a negative number to a positive will result in a
-number with a + sign.
-
-"
+number with a + sign."
   :motion nil
   (interactive "*<c><R>")
   (let ((amount (or amount 1))
@@ -238,7 +236,7 @@ number with a + sign.
 
 ;;;###autoload (autoload 'evil-numbers/dec-at-pt "evil-numbers" nil t)
 (evil-define-operator evil-numbers/dec-at-pt (amount beg end type &optional incremental padded)
-  "Decrement the number at point or after point before end-of-line by AMOUNT.
+  "Decrement the number at point or after point before `end-of-line' by AMOUNT.
 
 If a region is active, decrement all the numbers at a point by AMOUNT.
 
@@ -249,7 +247,7 @@ This function uses `evil-numbers/inc-at-pt'"
 
 ;;;###autoload (autoload 'evil-numbers/inc-at-pt-incremental "evil-numbers" nil t)
 (evil-define-operator evil-numbers/inc-at-pt-incremental (amount beg end type padded)
-  "Increment the number at point or after point before end-of-line by AMOUNT.
+  "Increment the number at point or after point before `end-of-line' by AMOUNT.
 
 If a region is active, increment all the numbers at a point by AMOUNT*n, where
 n is the index of the number among the numbers in the region, starting at 1.
@@ -261,7 +259,7 @@ on."
 
 ;;;###autoload (autoload 'evil-numbers/dec-at-pt-incremental "evil-numbers" nil t)
 (evil-define-operator evil-numbers/dec-at-pt-incremental (amount beg end type padded)
-  "Like `evil-numbers/inc-at-pt-incremental' but with negated argument AMOUNT"
+  "Like `evil-numbers/inc-at-pt-incremental' but with negated argument AMOUNT."
   :motion nil
   (interactive "*<c><R>")
   (evil-numbers/inc-at-pt (- (or amount 1)) beg end type 'incemental padded))
@@ -269,10 +267,11 @@ on."
 ;;; utils
 
 (defun evil-numbers/search-number ()
-  "Return non-nil if a binary, octal, hexadecimal or decimal literal at or after point.
+  "Return non-nil if a number literal at or after point.
+
 If point is already within or after a literal it stays.
 
-The literals have to be in the following forms:
+Literals may be in binary, octal, hexadecimal or decimal forms:
 binary: 0[bB][01]+, e.g. 0b101 or 0B0
 octal: 0[oO][0-7]+, e.g. 0o42 or 0O5
 hexadecimal 0[xX][0-9a-fA-F]+, e.g. 0xBEEF or 0Xcafe
@@ -299,7 +298,11 @@ decimal: [0-9]+, e.g. 42 or 23"
 	   (<= 0 (skip-chars-forward "bBoOxX"))))))
 
 (defun evil-numbers/search-and-replace (look-back skip-back search-forward inc base)
-  "When looking back at LOOK-BACK skip chars SKIP-BACK backwards and replace number incremented by INC in BASE and return non-nil."
+  "Perform the increment/decrement on the current line.
+
+When looking back at LOOK-BACK skip chars SKIP-BACK backwards,
+then SEARCH-FORWARD and replace number incremented by INC in BASE
+and return non-nil."
   (when (looking-back look-back)
     (skip-chars-backward skip-back)
     (search-forward-regexp search-forward)
@@ -311,7 +314,7 @@ decimal: [0-9]+, e.g. 42 or 23"
     t))
 
 (defun evil-numbers/format (num width base)
-  "Format NUM with at least WIDTH space in BASE"
+  "Format NUM with at least WIDTH space in BASE."
   (cond
    ((= base 2) (evil-numbers/format-binary num width))
    ((= base 8) (format (format "%%0%do" width) num))

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -87,9 +87,14 @@
                          (aref "₀₁₂₃₄₅₆₇₈₉" i)))
             (number-sequence 0 9)))))
 
+(defgroup evil-numbers nil
+  ""
+  :group 'convenience)
+
 ;;;###autoload
 (defcustom evil-numbers/padDefault nil
   "Whether numbers are padded by default"
+  :group 'evil-numbers
   :type 'boolean
   :options '(nil t))
 

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2011 by Michael Markert
 ;;               2018 by Jan Path
 ;; Author: Michael Markert <markert.michael@googlemail.com>
+;; Maintainer: Jan Path <jan@jpath.de>
 ;; Contributors: Matthew Fidler <matthew.fidler@gmail.com>
 ;;               Michael Markert <markert.michael@gmail.com>
 ;;               Jan Path <jan@jpath.de>

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -283,14 +283,14 @@ decimal: [0-9]+, e.g. 42 or 23"
    ;; Search for number in rest of line match 0 of specifier or digit,
    ;; being in a literal and after specifier is handled above.
    (and
-	  (re-search-forward "[[:digit:]⁰¹²³⁴⁵⁶⁷⁸⁹₀₁₂₃₄₅₆₇₈₉]" (point-at-eol) t)
-	  (or
-	   (not (memq (char-after) '(?b ?B ?o ?O ?x ?X)))
-	   (/= (char-before) ?0)
-	   (and (> (point) 2)				; Should also take bofp into consideration.
-		      (not (looking-back "\\W0" 2)))
-	   ;; Skip format specifiers and interpret as boolean.
-	   (<= 0 (skip-chars-forward "bBoOxX"))))))
+    (re-search-forward "[[:digit:]⁰¹²³⁴⁵⁶⁷⁸⁹₀₁₂₃₄₅₆₇₈₉]" (point-at-eol) t)
+    (or
+     (not (memq (char-after) '(?b ?B ?o ?O ?x ?X)))
+     (/= (char-before) ?0)
+     (and (> (point) 2) ;; Should also take bofp into consideration.
+          (not (looking-back "\\W0" 2)))
+     ;; Skip format specifiers and interpret as boolean.
+     (<= 0 (skip-chars-forward "bBoOxX"))))))
 
 (defun evil-numbers/search-and-replace (look-back skip-back search-forward inc base)
   "Perform the increment/decrement on the current line.
@@ -304,8 +304,8 @@ and return non-nil."
     (replace-match (evil-numbers/format (+ inc (string-to-number (match-string 1) base))
                                         (if evil-numbers/padDefault (length (match-string 1)) 1)
                                         base))
-	  ;; Moves point one position back to conform with VIM.
-	  (forward-char -1)
+    ;; Moves point one position back to conform with VIM.
+    (forward-char -1)
     t))
 
 (defun evil-numbers/format (num width base)

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -65,6 +65,8 @@
 
 ;;; Code:
 
+(require 'evil)
+
 (defconst evil-numbers/superscript-alist
   (cons
    (cons ?- ?⁻)

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -284,7 +284,8 @@ decimal: [0-9]+, e.g. 42 or 23"
                          (in "₀₁₂₃₄₅₆₇₈₉" )
                          (and "0" (or (and (in "bB") (*? (in "01")))
                                       (and (in "oO") (*? (in "0-7")))
-                                      (and (in "xX") (*? (in digit "A-Fa-f"))))))))
+                                      (and (in "xX") (*? (in digit "A-Fa-f")))))))
+                 (point-at-bol))
    ;; search for number in rest of line
    ;; match 0 of specifier or digit, being in a literal and after specifier is
    ;; handled above
@@ -300,7 +301,7 @@ decimal: [0-9]+, e.g. 42 or 23"
 
 (defun evil-numbers/search-and-replace (look-back skip-back search-forward inc base)
   "When looking back at LOOK-BACK skip chars SKIP-BACK backwards and replace number incremented by INC in BASE and return non-nil."
-  (when (looking-back look-back)
+  (when (looking-back look-back (point-at-bol))
     (skip-chars-backward skip-back)
     (search-forward-regexp search-forward)
     (replace-match (evil-numbers/format (+ inc (string-to-number (match-string 1) base))

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -1,4 +1,4 @@
-;;; evil-numbers.el --- increment/decrement numbers like in vim -*- lexical-binding: t -*-
+;;; evil-numbers.el --- Increment/decrement numbers like in VIM -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011 by Michael Markert
 ;;               2020 by Julia Path
@@ -11,7 +11,8 @@
 ;; Git-Repository: git://github.com/juliapath/evil-numbers.git
 ;; Created: 2011-09-02
 ;; Version: 0.5
-;; Keywords: numbers increment decrement octal hex binary
+;; Package-Requires: ((emacs "24.1"))
+;; Keywords: convenience tools
 
 ;; This file is not part of GNU Emacs.
 

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -59,7 +59,7 @@
 ;;; Code:
 
 ;;;###autoload
-(defun evil-numbers/inc-at-pt (amount &optional no-region)
+(defun evil-numbers/inc-at-pt (amount &optional no-region &optional incremental)
   "Increment the number at point or after point before end-of-line by `amount'.
 When region is selected, increment all numbers in the region by `amount'
 
@@ -67,18 +67,23 @@ NO-REGION is internal flag that allows
 `evil-numbers/inc-at-point' to be called recursively when
 applying the regional features of `evil-numbers/inc-at-point'.
 
+INCREMENTAL causes the first number to be increased by 1*amount, the second by
+2*amount and so on.
+
 "
   (interactive "p*")
   (cond
    ((and (not no-region) (region-active-p))
     (let (deactivate-mark
           (rb (region-beginning))
-          (re (region-end)))
+          (re (region-end))
+          (count 1))
       (save-excursion
         (save-match-data
           (goto-char rb)
           (while (re-search-forward "\\(?:0\\(?:[Bb][01]+\\|[Oo][0-7]+\\|[Xx][0-9A-Fa-f]+\\)\\|-?[0-9]+\\)" re t)
-            (evil-numbers/inc-at-pt amount 'no-region)
+            (evil-numbers/inc-at-pt (* amount count) 'no-region)
+            (if incremental (setq count (+ count 1)))
             ;; Undo vim compatability.
             (forward-char 1)))))
     (setq deactivate-mark t))
@@ -120,6 +125,23 @@ If a region is active, decrement all the numbers at a point by `amount'.
 This function uses `evil-numbers/inc-at-pt'"
   (interactive "p*")
   (evil-numbers/inc-at-pt (- amount)))
+
+;;;###autoload
+(defun evil-numbers/inc-at-pt-incremental (amount)
+  "Increment the number at point or after point before end-of-line by `amount'.
+
+If a region is active, increment all the numbers at a point by `amount'*n, where
+`n' is the index of the number among the numbers in the region, starting at 1.
+That is increment the first number by `amount', the second by 2*`amount', and so
+on."
+  (interactive "p*")
+  (evil-numbers/inc-at-pt amount nil 'incremental))
+
+;;;###autoload
+(defun evil-numbers/dec-at-pt-incremental (amount)
+  "Like `evil-numbers/inc-at-pt-incremental' but with negated argument `amount'"
+  (interactive "p*")
+  (evil-numbers/inc-at-pt-incremental (- amount)))
 
 ;;; utils
 

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -59,7 +59,7 @@
 ;;; Code:
 
 ;;;###autoload
-(defun evil-numbers/inc-at-pt (amount &optional no-region &optional incremental)
+(defun evil-numbers/inc-at-pt (amount &optional no-region incremental)
   "Increment the number at point or after point before end-of-line by `amount'.
 When region is selected, increment all numbers in the region by `amount'
 

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -30,10 +30,10 @@
 
 ;;; Commentary:
 
-;; Increment / Decrement binary, octal, decimal and hex literals
+;; Increment / Decrement binary, octal, decimal and hex literals.
 
-;; works like C-a/C-x in vim, i.e. searches for number up to eol and then
-;; increments or decrements and keep zero padding up
+;; Works like C-a/C-x in vim, i.e. searches for number up to EOL and
+;; then increments or decrements and keep zero padding up.
 
 ;; Known Bugs:
 ;; See http://github.com/juliapath/evil-numbers/issues
@@ -147,11 +147,11 @@ number with a + sign."
                (evil-with-restriction beg end
                  (while (re-search-forward "\\(?:0\\(?:[Bb][01]+\\|[Oo][0-7]+\\|[Xx][0-9A-Fa-f]+\\)\\|[+-]?[0-9]+\\|[⁻⁺]?[⁰¹²³⁴⁵⁶⁷⁸⁹]\\|[₋₊]?[₀₁₂₃₄₅₆₇₈₉]\\)" nil t)
                    ;; Backward char, to cancel out the forward-char below. We need
-                   ;; this, as re-search-forwards puts us behind the match.
+                   ;; this, as `re-search-forwards' puts us behind the match.
                    (backward-char)
                    (evil-numbers/inc-at-pt (* amount count) nil nil nil)
                    (if incremental (setq count (+ count 1)))
-                   ;; Undo vim compatability.
+                   ;; Undo VIM compatibility.
                    (forward-char 1)))))))))
      (t (save-match-data
           ;; forward-char, so that we do not match the number directly behind us.
@@ -188,22 +188,22 @@ number with a + sign."
                                     (if signed "+" "")
                                     (if padded len 0))
                             output))))
-                       ;; Moves point one position back to conform with Vim
+                       ;; Moves point one position back to conform with VIM
                        (forward-char -1)
                        t))))
               (or
-               ;; find binary literals
+               ;; Find binary literals.
                (evil-numbers/search-and-replace "0[bB][01]+" "01" "\\([01]+\\)" amount 2)
 
-               ;; find octal literals
+               ;; Find octal literals.
                (evil-numbers/search-and-replace "0[oO][0-7]+" "01234567" "\\([0-7]+\\)" amount 8)
 
-               ;; find hex literals
+               ;; Find hex literals.
                (evil-numbers/search-and-replace "0[xX][0-9a-fA-F]*"
                                                 "0123456789abcdefABCDEF"
                                                 "\\([0-9a-fA-F]+\\)" amount 16)
 
-               ;; find superscript literals
+               ;; Find superscript literals.
                (funcall
                 replace-with
                 (lambda (x)
@@ -214,7 +214,7 @@ number with a + sign."
                    (evil-numbers/swap-alist evil-numbers/superscript-alist)
                    x)))
 
-               ;; find subscript literals
+               ;; Find subscript literals.
                (funcall
                 replace-with
                 (lambda (x)
@@ -225,7 +225,7 @@ number with a + sign."
                    (evil-numbers/swap-alist evil-numbers/subscript-alist)
                    x)))
 
-               ;; find normal decimal literals
+               ;; Find normal decimal literals.
                (funcall replace-with (lambda (x) x) (lambda (x) x))
                (error "No number at point or until end of line")))))))))
 
@@ -259,7 +259,7 @@ on."
   (interactive "*<c><R>")
   (evil-numbers/inc-at-pt (- (or amount 1)) beg end type 'incemental padded))
 
-;;; utils
+;;; Utilities.
 
 (defun evil-numbers/search-number ()
   "Return non-nil if a number literal at or after point.
@@ -272,7 +272,7 @@ octal: 0[oO][0-7]+, e.g. 0o42 or 0O5
 hexadecimal 0[xX][0-9a-fA-F]+, e.g. 0xBEEF or 0Xcafe
 decimal: [0-9]+, e.g. 42 or 23"
   (or
-   ;; numbers or format specifier in front
+   ;; Numbers or format specifier in front.
    (looking-back (rx (or (+? digit)
                          (in "⁰¹²³⁴⁵⁶⁷⁸⁹")
                          (in "₀₁₂₃₄₅₆₇₈₉" )
@@ -280,17 +280,16 @@ decimal: [0-9]+, e.g. 42 or 23"
                                       (and (in "oO") (*? (in "0-7")))
                                       (and (in "xX") (*? (in digit "A-Fa-f")))))))
                  (point-at-bol))
-   ;; search for number in rest of line
-   ;; match 0 of specifier or digit, being in a literal and after specifier is
-   ;; handled above
+   ;; Search for number in rest of line match 0 of specifier or digit,
+   ;; being in a literal and after specifier is handled above.
    (and
 	  (re-search-forward "[[:digit:]⁰¹²³⁴⁵⁶⁷⁸⁹₀₁₂₃₄₅₆₇₈₉]" (point-at-eol) t)
 	  (or
 	   (not (memq (char-after) '(?b ?B ?o ?O ?x ?X)))
 	   (/= (char-before) ?0)
-	   (and (> (point) 2)				; Should also take bofp into consideration
+	   (and (> (point) 2)				; Should also take bofp into consideration.
 		      (not (looking-back "\\W0" 2)))
-	   ;; skip format specifiers and interpret as bool
+	   ;; Skip format specifiers and interpret as boolean.
 	   (<= 0 (skip-chars-forward "bBoOxX"))))))
 
 (defun evil-numbers/search-and-replace (look-back skip-back search-forward inc base)
@@ -305,7 +304,7 @@ and return non-nil."
     (replace-match (evil-numbers/format (+ inc (string-to-number (match-string 1) base))
                                         (if evil-numbers/padDefault (length (match-string 1)) 1)
                                         base))
-	  ;; Moves point one position back to conform with Vim
+	  ;; Moves point one position back to conform with VIM.
 	  (forward-char -1)
     t))
 

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -87,6 +87,7 @@
                          (aref "₀₁₂₃₄₅₆₇₈₉" i)))
             (number-sequence 0 9)))))
 
+;;;###autoload
 (defcustom evil-numbers/padDefault nil
   "Whether numbers are padded by default"
   :type 'boolean
@@ -102,7 +103,7 @@
    (if (stringp string) #'concat (lambda (x) x))
    (mapcar (lambda (c) (cdr (assoc c alist))) string)))
 
-;;;###autoload
+;;;###autoload (autoload 'evil-numbers/inc-at-pt "evil-numbers")
 (evil-define-operator evil-numbers/inc-at-pt (amount beg end type &optional incremental padded)
   "Increment the number at point or after point before end-of-line by AMOUNT.
 When region is selected, increment all numbers in the region by AMOUNT
@@ -227,7 +228,7 @@ number with a + sign.
                (funcall replace-with (lambda (x) x) (lambda (x) x))
                (error "No number at point or until end of line")))))))))
 
-;;;###autoload
+;;;###autoload (autoload 'evil-numbers/dec-at-pt "evil-numbers")
 (evil-define-operator evil-numbers/dec-at-pt (amount beg end type &optional incremental padded)
   "Decrement the number at point or after point before end-of-line by AMOUNT.
 
@@ -238,7 +239,7 @@ This function uses `evil-numbers/inc-at-pt'"
   (interactive "*<c><R>")
   (evil-numbers/inc-at-pt (- (or amount 1)) beg end type incremental padded))
 
-;;;###autoload
+;;;###autoload (autoload 'evil-numbers/inc-at-pt-incremental "evil-numbers")
 (evil-define-operator evil-numbers/inc-at-pt-incremental (amount beg end type padded)
   "Increment the number at point or after point before end-of-line by AMOUNT.
 
@@ -250,7 +251,7 @@ on."
   (interactive "*<c><R>")
   (evil-numbers/inc-at-pt amount beg end type 'incremental padded))
 
-;;;###autoload
+;;;###autoload (autoload 'evil-numbers/dec-at-pt-incremental "evil-numbers")
 (evil-define-operator evil-numbers/dec-at-pt-incremental (amount beg end type padded)
   "Like `evil-numbers/inc-at-pt-incremental' but with negated argument AMOUNT"
   :motion nil

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -109,7 +109,7 @@
    (if (stringp string) #'concat (lambda (x) x))
    (mapcar (lambda (c) (cdr (assoc c alist))) string)))
 
-;;;###autoload (autoload 'evil-numbers/inc-at-pt "evil-numbers")
+;;;###autoload (autoload 'evil-numbers/inc-at-pt "evil-numbers" nil t)
 (evil-define-operator evil-numbers/inc-at-pt (amount beg end type &optional incremental padded)
   "Increment the number at point or after point before end-of-line by AMOUNT.
 When region is selected, increment all numbers in the region by AMOUNT
@@ -234,7 +234,7 @@ number with a + sign.
                (funcall replace-with (lambda (x) x) (lambda (x) x))
                (error "No number at point or until end of line")))))))))
 
-;;;###autoload (autoload 'evil-numbers/dec-at-pt "evil-numbers")
+;;;###autoload (autoload 'evil-numbers/dec-at-pt "evil-numbers" nil t)
 (evil-define-operator evil-numbers/dec-at-pt (amount beg end type &optional incremental padded)
   "Decrement the number at point or after point before end-of-line by AMOUNT.
 
@@ -245,7 +245,7 @@ This function uses `evil-numbers/inc-at-pt'"
   (interactive "*<c><R>")
   (evil-numbers/inc-at-pt (- (or amount 1)) beg end type incremental padded))
 
-;;;###autoload (autoload 'evil-numbers/inc-at-pt-incremental "evil-numbers")
+;;;###autoload (autoload 'evil-numbers/inc-at-pt-incremental "evil-numbers" nil t)
 (evil-define-operator evil-numbers/inc-at-pt-incremental (amount beg end type padded)
   "Increment the number at point or after point before end-of-line by AMOUNT.
 
@@ -257,7 +257,7 @@ on."
   (interactive "*<c><R>")
   (evil-numbers/inc-at-pt amount beg end type 'incremental padded))
 
-;;;###autoload (autoload 'evil-numbers/dec-at-pt-incremental "evil-numbers")
+;;;###autoload (autoload 'evil-numbers/dec-at-pt-incremental "evil-numbers" nil t)
 (evil-define-operator evil-numbers/dec-at-pt-incremental (amount beg end type padded)
   "Like `evil-numbers/inc-at-pt-incremental' but with negated argument AMOUNT"
   :motion nil

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -69,7 +69,7 @@
 
 (require 'evil)
 
-(defconst evil-numbers/superscript-alist
+(defconst evil-numbers--superscript-alist
   (cons
    (cons ?- ?⁻)
    (cons
@@ -79,7 +79,7 @@
                          (aref "⁰¹²³⁴⁵⁶⁷⁸⁹" i)))
             (number-sequence 0 9)))))
 
-(defconst evil-numbers/subscript-alist
+(defconst evil-numbers--subscript-alist
   (cons
    (cons ?- ?₋)
    (cons
@@ -100,11 +100,11 @@
   :type 'boolean
   :options '(nil t))
 
-(defun evil-numbers/swap-alist (alist)
+(defun evil-numbers--swap-alist (alist)
   "Swap association list ALIST."
   (mapcar (lambda (x) (cons (cdr x) (car x))) alist))
 
-(defun evil-numbers/translate-with-alist (alist string)
+(defun evil-numbers--translate-with-alist (alist string)
   "Translate every symbol in STRING using ALIST."
   (funcall
    (if (stringp string) #'concat (lambda (x) x))
@@ -158,7 +158,7 @@ number with a + sign."
       (save-match-data
         ;; forward-char, so that we do not match the number directly behind us.
         (forward-char)
-        (if (not (evil-numbers/search-number))
+        (if (not (evil-numbers--search-number))
             (error "No number at point or until end of line")
           (let ((replace-with
                  (lambda (from to)
@@ -195,13 +195,13 @@ number with a + sign."
                      t))))
             (or
              ;; Find binary literals.
-             (evil-numbers/search-and-replace "0[bB][01]+" "01" "\\([01]+\\)" amount 2)
+             (evil-numbers--search-and-replace "0[bB][01]+" "01" "\\([01]+\\)" amount 2)
 
              ;; Find octal literals.
-             (evil-numbers/search-and-replace "0[oO][0-7]+" "01234567" "\\([0-7]+\\)" amount 8)
+             (evil-numbers--search-and-replace "0[oO][0-7]+" "01234567" "\\([0-7]+\\)" amount 8)
 
              ;; Find hex literals.
-             (evil-numbers/search-and-replace "0[xX][0-9a-fA-F]*"
+             (evil-numbers--search-and-replace "0[xX][0-9a-fA-F]*"
                                               "0123456789abcdefABCDEF"
                                               "\\([0-9a-fA-F]+\\)" amount 16)
 
@@ -209,22 +209,22 @@ number with a + sign."
              (funcall
               replace-with
               (lambda (x)
-                (evil-numbers/translate-with-alist
-                 evil-numbers/superscript-alist x))
+                (evil-numbers--translate-with-alist
+                 evil-numbers--superscript-alist x))
               (lambda (x)
-                (evil-numbers/translate-with-alist
-                 (evil-numbers/swap-alist evil-numbers/superscript-alist)
+                (evil-numbers--translate-with-alist
+                 (evil-numbers--swap-alist evil-numbers--superscript-alist)
                  x)))
 
              ;; Find subscript literals.
              (funcall
               replace-with
               (lambda (x)
-                (evil-numbers/translate-with-alist
-                 evil-numbers/subscript-alist x))
+                (evil-numbers--translate-with-alist
+                 evil-numbers--subscript-alist x))
               (lambda (x)
-                (evil-numbers/translate-with-alist
-                 (evil-numbers/swap-alist evil-numbers/subscript-alist)
+                (evil-numbers--translate-with-alist
+                 (evil-numbers--swap-alist evil-numbers--subscript-alist)
                  x)))
 
              ;; Find normal decimal literals.
@@ -263,7 +263,7 @@ on."
 
 ;;; Utilities.
 
-(defun evil-numbers/search-number ()
+(defun evil-numbers--search-number ()
   "Return non-nil if a number literal at or after point.
 
 If point is already within or after a literal it stays.
@@ -294,7 +294,7 @@ decimal: [0-9]+, e.g. 42 or 23"
      ;; Skip format specifiers and interpret as boolean.
      (<= 0 (skip-chars-forward "bBoOxX"))))))
 
-(defun evil-numbers/search-and-replace (look-back skip-back search-forward inc base)
+(defun evil-numbers--search-and-replace (look-back skip-back search-forward inc base)
   "Perform the increment/decrement on the current line.
 
 When looking back at LOOK-BACK skip chars SKIP-BACK backwards,
@@ -303,22 +303,22 @@ and return non-nil."
   (when (looking-back look-back (point-at-bol))
     (skip-chars-backward skip-back)
     (search-forward-regexp search-forward)
-    (replace-match (evil-numbers/format (+ inc (string-to-number (match-string 1) base))
+    (replace-match (evil-numbers--format (+ inc (string-to-number (match-string 1) base))
                                         (if evil-numbers/padDefault (length (match-string 1)) 1)
                                         base))
     ;; Moves point one position back to conform with VIM.
     (forward-char -1)
     t))
 
-(defun evil-numbers/format (num width base)
+(defun evil-numbers--format (num width base)
   "Format NUM with at least WIDTH space in BASE."
   (cond
-   ((= base 2) (evil-numbers/format-binary num width))
+   ((= base 2) (evil-numbers-format-binary num width))
    ((= base 8) (format (format "%%0%do" width) num))
    ((= base 16) (format (format "%%0%dX" width) num))
    (t "")))
 
-(defun evil-numbers/format-binary (number &optional width fillchar)
+(defun evil-numbers-format-binary (number &optional width fillchar)
   "Format NUMBER as binary.
 Fill up to WIDTH with FILLCHAR (defaults to ?0) if binary
 representation of NUMBER is smaller."

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -102,15 +102,15 @@
 
 ;;;###autoload
 (evil-define-operator evil-numbers/inc-at-pt (amount beg end type &optional incremental padded)
-  "Increment the number at point or after point before end-of-line by `amount'.
-When region is selected, increment all numbers in the region by `amount'
+  "Increment the number at point or after point before end-of-line by AMOUNT.
+When region is selected, increment all numbers in the region by AMOUNT
 
 NO-REGION is internal flag that allows
 `evil-numbers/inc-at-point' to be called recursively when
 applying the regional features of `evil-numbers/inc-at-point'.
 
-INCREMENTAL causes the first number to be increased by 1*amount, the second by
-2*amount and so on.
+INCREMENTAL causes the first number to be increased by 1*AMOUNT, the second by
+2*AMOUNT and so on.
 
 PADDED is whether numbers should be padded (e.g. 10 -> 09). nil is default
 behaviour set by `evil-numbers/pad-default', t is the opposite of
@@ -227,9 +227,9 @@ number with a + sign.
 
 ;;;###autoload
 (evil-define-operator evil-numbers/dec-at-pt (amount beg end type &optional incremental padded)
-  "Decrement the number at point or after point before end-of-line by `amount'.
+  "Decrement the number at point or after point before end-of-line by AMOUNT.
 
-If a region is active, decrement all the numbers at a point by `amount'.
+If a region is active, decrement all the numbers at a point by AMOUNT.
 
 This function uses `evil-numbers/inc-at-pt'"
   :motion nil
@@ -238,11 +238,11 @@ This function uses `evil-numbers/inc-at-pt'"
 
 ;;;###autoload
 (evil-define-operator evil-numbers/inc-at-pt-incremental (amount beg end type padded)
-  "Increment the number at point or after point before end-of-line by `amount'.
+  "Increment the number at point or after point before end-of-line by AMOUNT.
 
-If a region is active, increment all the numbers at a point by `amount'*n, where
-`n' is the index of the number among the numbers in the region, starting at 1.
-That is increment the first number by `amount', the second by 2*`amount', and so
+If a region is active, increment all the numbers at a point by AMOUNT*n, where
+n is the index of the number among the numbers in the region, starting at 1.
+That is increment the first number by AMOUNT, the second by 2*AMOUNT, and so
 on."
   :motion nil
   (interactive "*<c><R>")
@@ -250,7 +250,7 @@ on."
 
 ;;;###autoload
 (evil-define-operator evil-numbers/dec-at-pt-incremental (amount beg end type padded)
-  "Like `evil-numbers/inc-at-pt-incremental' but with negated argument `amount'"
+  "Like `evil-numbers/inc-at-pt-incremental' but with negated argument AMOUNT"
   :motion nil
   (interactive "*<c><R>")
   (evil-numbers/inc-at-pt (- (or amount 1)) beg end type 'incemental padded))
@@ -288,7 +288,7 @@ decimal: [0-9]+, e.g. 42 or 23"
 	   (<= 0 (skip-chars-forward "bBoOxX"))))))
 
 (defun evil-numbers/search-and-replace (look-back skip-back search-forward inc base)
-  "When looking back at `LOOK-BACK' skip chars `SKIP-BACK'backwards and replace number incremented by `INC' in `BASE' and return non-nil."
+  "When looking back at LOOK-BACK skip chars SKIP-BACK backwards and replace number incremented by INC in BASE and return non-nil."
   (when (looking-back look-back)
     (skip-chars-backward skip-back)
     (search-forward-regexp search-forward)
@@ -300,7 +300,7 @@ decimal: [0-9]+, e.g. 42 or 23"
     t))
 
 (defun evil-numbers/format (num width base)
-  "Format `NUM' with at least `WIDTH' space in `BASE'"
+  "Format NUM with at least WIDTH space in BASE"
   (cond
    ((= base 2) (evil-numbers/format-binary num width))
    ((= base 8) (format (format "%%0%do" width) num))
@@ -308,9 +308,9 @@ decimal: [0-9]+, e.g. 42 or 23"
    (t "")))
 
 (defun evil-numbers/format-binary (number &optional width fillchar)
-  "Format `NUMBER' as binary.
-Fill up to `WIDTH' with `FILLCHAR' (defaults to ?0) if binary
-representation of `NUMBER' is smaller."
+  "Format NUMBER as binary.
+Fill up to WIDTH with FILLCHAR (defaults to ?0) if binary
+representation of NUMBER is smaller."
   (let (nums
         (fillchar (or fillchar ?0)))
     (while (> number 0)

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -1,4 +1,4 @@
-;;; evil-numbers.el --- increment/decrement numbers like in vim
+;;; evil-numbers.el --- increment/decrement numbers like in vim -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011 by Michael Markert
 ;;               2018 by Jan Path
@@ -158,12 +158,7 @@ number with a + sign."
           (forward-char)
           (if (not (evil-numbers/search-number))
               (error "No number at point or until end of line")
-            (let ((pad
-                   (lambda (len sign arg)
-                     (format
-                      (format "%%%s0%dd" (if sign "+" "") len)
-                      arg)))
-                  (replace-with
+            (let ((replace-with
                    (lambda (from to)
                      (skip-chars-backward
                       (funcall from "0123456789"))

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -283,7 +283,7 @@ decimal: [0-9]+, e.g. 42 or 23"
     (skip-chars-backward skip-back)
     (search-forward-regexp search-forward)
     (replace-match (evil-numbers/format (+ inc (string-to-number (match-string 1) base))
-                                        (length (match-string 1))
+                                        (if evil-numbers/padDefault (length (match-string 1)) 1)
                                         base))
 	  ;; Moves point one position back to conform with Vim
 	  (forward-char -1)

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -154,81 +154,82 @@ number with a + sign."
                    (if incremental (setq count (+ count 1)))
                    ;; Undo VIM compatibility.
                    (forward-char 1)))))))))
-     (t (save-match-data
-          ;; forward-char, so that we do not match the number directly behind us.
-          (forward-char)
-          (if (not (evil-numbers/search-number))
-              (error "No number at point or until end of line")
-            (let ((replace-with
-                   (lambda (from to)
-                     (skip-chars-backward
-                      (funcall from "0123456789"))
-                     (skip-chars-backward
-                      (funcall from "+-") (- (point) 1))
-                     (when (looking-at
-                            (format
-                             "[%s]?\\([%s]+\\)"
-                             (funcall from "-+")
-                             (funcall from "0123456789")))
-                       (replace-match
-                        (funcall
-                         from
-                         (let* ((padded
-                                 (or padded
-                                     (eq ?0 (string-to-char (match-string 1)))))
-                                (input (string-to-number
-                                        (funcall to (match-string 0))))
-                                (output (+ amount input))
-                                (len (- (match-end 0) (match-beginning 0)))
-                                (signed (and
-                                         (memq (string-to-char (match-string 0))
-                                               (funcall from '(?+ ?-)))
-                                         (or padded (>= input 0)))))
-                           (format
-                            (format "%%%s0%dd"
-                                    (if signed "+" "")
-                                    (if padded len 0))
-                            output))))
-                       ;; Moves point one position back to conform with VIM
-                       (forward-char -1)
-                       t))))
-              (or
-               ;; Find binary literals.
-               (evil-numbers/search-and-replace "0[bB][01]+" "01" "\\([01]+\\)" amount 2)
+     (t
+      (save-match-data
+        ;; forward-char, so that we do not match the number directly behind us.
+        (forward-char)
+        (if (not (evil-numbers/search-number))
+            (error "No number at point or until end of line")
+          (let ((replace-with
+                 (lambda (from to)
+                   (skip-chars-backward
+                    (funcall from "0123456789"))
+                   (skip-chars-backward
+                    (funcall from "+-") (- (point) 1))
+                   (when (looking-at
+                          (format
+                           "[%s]?\\([%s]+\\)"
+                           (funcall from "-+")
+                           (funcall from "0123456789")))
+                     (replace-match
+                      (funcall
+                       from
+                       (let* ((padded
+                               (or padded
+                                   (eq ?0 (string-to-char (match-string 1)))))
+                              (input (string-to-number
+                                      (funcall to (match-string 0))))
+                              (output (+ amount input))
+                              (len (- (match-end 0) (match-beginning 0)))
+                              (signed (and
+                                       (memq (string-to-char (match-string 0))
+                                             (funcall from '(?+ ?-)))
+                                       (or padded (>= input 0)))))
+                         (format
+                          (format "%%%s0%dd"
+                                  (if signed "+" "")
+                                  (if padded len 0))
+                          output))))
+                     ;; Moves point one position back to conform with VIM
+                     (forward-char -1)
+                     t))))
+            (or
+             ;; Find binary literals.
+             (evil-numbers/search-and-replace "0[bB][01]+" "01" "\\([01]+\\)" amount 2)
 
-               ;; Find octal literals.
-               (evil-numbers/search-and-replace "0[oO][0-7]+" "01234567" "\\([0-7]+\\)" amount 8)
+             ;; Find octal literals.
+             (evil-numbers/search-and-replace "0[oO][0-7]+" "01234567" "\\([0-7]+\\)" amount 8)
 
-               ;; Find hex literals.
-               (evil-numbers/search-and-replace "0[xX][0-9a-fA-F]*"
-                                                "0123456789abcdefABCDEF"
-                                                "\\([0-9a-fA-F]+\\)" amount 16)
+             ;; Find hex literals.
+             (evil-numbers/search-and-replace "0[xX][0-9a-fA-F]*"
+                                              "0123456789abcdefABCDEF"
+                                              "\\([0-9a-fA-F]+\\)" amount 16)
 
-               ;; Find superscript literals.
-               (funcall
-                replace-with
-                (lambda (x)
-                  (evil-numbers/translate-with-alist
-                   evil-numbers/superscript-alist x))
-                (lambda (x)
-                  (evil-numbers/translate-with-alist
-                   (evil-numbers/swap-alist evil-numbers/superscript-alist)
-                   x)))
+             ;; Find superscript literals.
+             (funcall
+              replace-with
+              (lambda (x)
+                (evil-numbers/translate-with-alist
+                 evil-numbers/superscript-alist x))
+              (lambda (x)
+                (evil-numbers/translate-with-alist
+                 (evil-numbers/swap-alist evil-numbers/superscript-alist)
+                 x)))
 
-               ;; Find subscript literals.
-               (funcall
-                replace-with
-                (lambda (x)
-                  (evil-numbers/translate-with-alist
-                   evil-numbers/subscript-alist x))
-                (lambda (x)
-                  (evil-numbers/translate-with-alist
-                   (evil-numbers/swap-alist evil-numbers/subscript-alist)
-                   x)))
+             ;; Find subscript literals.
+             (funcall
+              replace-with
+              (lambda (x)
+                (evil-numbers/translate-with-alist
+                 evil-numbers/subscript-alist x))
+              (lambda (x)
+                (evil-numbers/translate-with-alist
+                 (evil-numbers/swap-alist evil-numbers/subscript-alist)
+                 x)))
 
-               ;; Find normal decimal literals.
-               (funcall replace-with (lambda (x) x) (lambda (x) x))
-               (error "No number at point or until end of line")))))))))
+             ;; Find normal decimal literals.
+             (funcall replace-with (lambda (x) x) (lambda (x) x))
+             (error "No number at point or until end of line")))))))))
 
 ;;;###autoload (autoload 'evil-numbers/dec-at-pt "evil-numbers" nil t)
 (evil-define-operator evil-numbers/dec-at-pt (amount beg end type &optional incremental padded)

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -168,7 +168,9 @@ number with a + sign.
                   (replace-with
                    (lambda (from to)
                      (skip-chars-backward
-                      (funcall from "+-0123456789"))
+                      (funcall from "0123456789"))
+                     (skip-chars-backward
+                      (funcall from "+-") (- (point) 1))
                      (when (looking-at
                             (format
                              "[%s]?\\([%s]+\\)"

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -86,11 +86,16 @@ INCREMENTAL causes the first number to be increased by 1*amount, the second by
            (lambda (beg end)
              (evil-with-restriction beg end
                (while (re-search-forward "\\(?:0\\(?:[Bb][01]+\\|[Oo][0-7]+\\|[Xx][0-9A-Fa-f]+\\)\\|-?[0-9]+\\)" nil t)
+                 ;; Backward char, to cancel out the forward-char below. We need
+                 ;; this, as re-search-forwards puts us behind the match.
+                 (backward-char)
                  (evil-numbers/inc-at-pt (* amount count) nil nil nil)
                  (if incremental (setq count (+ count 1)))
                  ;; Undo vim compatability.
                  (forward-char 1)))))))))
    (t (save-match-data
+        ;; forward-char, so that we do not match the number directly behind us.
+        (forward-char)
         (if (not (evil-numbers/search-number))
             (error "No number at point or until end of line")
           (or

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -1,14 +1,14 @@
 ;;; evil-numbers.el --- increment/decrement numbers like in vim -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011 by Michael Markert
-;;               2018 by Jan Path
+;;               2020 by Julia Path
 ;; Author: Michael Markert <markert.michael@googlemail.com>
-;; Maintainer: Jan Path <jan@jpath.de>
+;; Maintainer: Julia Path <julia@jpath.de>
 ;; Contributors: Matthew Fidler <matthew.fidler@gmail.com>
 ;;               Michael Markert <markert.michael@gmail.com>
-;;               Jan Path <jan@jpath.de>
-;; URL: http://github.com/janpath/evil-numbers
-;; Git-Repository: git://github.com/janpath/evil-numbers.git
+;;               Julia Path <julia@jpath.de>
+;; URL: http://github.com/juliapath/evil-numbers
+;; Git-Repository: git://github.com/juliapath/evil-numbers.git
 ;; Created: 2011-09-02
 ;; Version: 0.5
 ;; Keywords: numbers increment decrement octal hex binary
@@ -36,7 +36,7 @@
 ;; increments or decrements and keep zero padding up
 
 ;; Known Bugs:
-;; See http://github.com/janpath/evil-numbers/issues
+;; See http://github.com/juliapath/evil-numbers/issues
 
 ;; Install:
 

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -75,13 +75,11 @@ INCREMENTAL causes the first number to be increased by 1*amount, the second by
   (cond
    ((and (not no-region) (region-active-p))
     (let (deactivate-mark
-          (rb (region-beginning))
-          (re (region-end))
           (count 1))
       (save-excursion
         (save-match-data
-          (goto-char rb)
-          (while (re-search-forward "\\(?:0\\(?:[Bb][01]+\\|[Oo][0-7]+\\|[Xx][0-9A-Fa-f]+\\)\\|-?[0-9]+\\)" re t)
+          (if (< (mark) (point)) (exchange-point-and-mark))
+          (while (re-search-forward "\\(?:0\\(?:[Bb][01]+\\|[Oo][0-7]+\\|[Xx][0-9A-Fa-f]+\\)\\|-?[0-9]+\\)" (region-end) t)
             (evil-numbers/inc-at-pt (* amount count) 'no-region)
             (if incremental (setq count (+ count 1)))
             ;; Undo vim compatability.

--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -1,14 +1,15 @@
 ;;; evil-numbers.el --- increment/decrement numbers like in vim
 
 ;; Copyright (C) 2011 by Michael Markert
+;;               2018 by Jan Path
 ;; Author: Michael Markert <markert.michael@googlemail.com>
-;; Contributors:
-;;               Matthew Fidler <matthew.fidler@gmail.com>
+;; Contributors: Matthew Fidler <matthew.fidler@gmail.com>
 ;;               Michael Markert <markert.michael@gmail.com>
-;; URL: http://github.com/cofi/evil-numbers
-;; Git-Repository: git://github.com/cofi/evil-numbers.git
+;;               Jan Path <jan@jpath.de>
+;; URL: http://github.com/janpath/evil-numbers
+;; Git-Repository: git://github.com/janpath/evil-numbers.git
 ;; Created: 2011-09-02
-;; Version: 0.4
+;; Version: 0.5
 ;; Keywords: numbers increment decrement octal hex binary
 
 ;; This file is not part of GNU Emacs.
@@ -34,7 +35,7 @@
 ;; increments or decrements and keep zero padding up
 
 ;; Known Bugs:
-;; See http://github.com/cofi/evil-numbers/issues
+;; See http://github.com/janpath/evil-numbers/issues
 
 ;; Install:
 
@@ -44,14 +45,20 @@
 
 ;; (global-set-key (kbd "C-c +") 'evil-numbers/inc-at-pt)
 ;; (global-set-key (kbd "C-c -") 'evil-numbers/dec-at-pt)
+;; (global-set-key (kbd "C-c C-+") 'evil-numbers/inc-at-pt-incremental)
+;; (global-set-key (kbd "C-c C--") 'evil-numbers/dec-at-pt-incremental)
 
 ;; or only in evil's normal and visual state:
 
 ;; (define-key evil-normal-state-map (kbd "C-c +") 'evil-numbers/inc-at-pt)
 ;; (define-key evil-visual-state-map (kbd "C-c +") 'evil-numbers/inc-at-pt)
+;; (define-key evil-normal-state-map (kbd "C-c C-+") 'evil-numbers/inc-at-pt-incremental)
+;; (define-key evil-visual-state-map (kbd "C-c C-+") 'evil-numbers/inc-at-pt-incremental)
 ;;
 ;; (define-key evil-normal-state-map (kbd "C-c -") 'evil-numbers/dec-at-pt)
 ;; (define-key evil-visual-state-map (kbd "C-c -") 'evil-numbers/dec-at-pt)
+;; (define-key evil-normal-state-map (kbd "C-c C--") 'evil-numbers/dec-at-pt-incremental)
+;; (define-key evil-visual-state-map (kbd "C-c C--") 'evil-numbers/dec-at-pt-incremental)
 
 ;; Usage:
 ;; Go and play with your numbers!
@@ -107,7 +114,10 @@ INCREMENTAL causes the first number to be increased by 1*amount, the second by
 
 PADDED is whether numbers should be padded (e.g. 10 -> 09). nil is default
 behaviour set by `evil-numbers/pad-default', t is the opposite of
-`evil-numbers/pad-default','(t) enables padding and '(nil) disables padding.
+`evil-numbers/pad-default', '(t) enables padding and '(nil) disables padding.
+Numbers with a leading zero are always padded. Signs are preserved when padding
+is enabled, i.e. increasing a negative number to a positive will result in a
+number with a + sign.
 
 "
   :motion nil


### PR DESCRIPTION
Cleanup: use '--' separator for private functions

Currently package-lint-current-buffer warns about breaking
the convention of using dashes for separators.

While this can't be changed with the public functions,
the convention can be used for private functions.

This also has the advantage of abbreviating function display
with nameless-mode.
